### PR TITLE
ensure build.ps1 fails when build fails

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -3,6 +3,8 @@ Param(
     [string]$Target = "default"
 )
 
+$ErrorActionPreference = "Stop";
+
 # Install .NET Core
 
 $dotNetVersionString = dotnet --version


### PR DESCRIPTION
You'll want this if you ever start building on a CI server. E.g. on Appveyor, without this, the build will not fail if `dotnet run` fails, as documented here: https://www.appveyor.com/docs/build-configuration/#interpreters-and-scripts