### PR TITLE
use Run() instead of Read()

### DIFF
--- a/build/Program.cs
+++ b/build/Program.cs
@@ -49,7 +49,7 @@ namespace build
                 foreach(var versionInfoFile in Directory.GetFiles(Directory.GetCurrentDirectory(), "*", SearchOption.AllDirectories)
                     .Where(path => path.Contains("VersionInfo.cs")))
                 {
-                    Read("git", $"checkout {versionInfoFile}");
+                    Run("git", $"checkout {versionInfoFile}");
                 }
             });
             Target(Default, DependsOn(VersionAssembly, Build, RevertVersionFiles));


### PR DESCRIPTION
It turns out that a successful `git checkout` has no output anyway, so may as well use `Run()` instead of `Read()`, since the return value is not being used.